### PR TITLE
Fixed issue with requirements file.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-pkg-resources==0.0.0
 SQLAlchemy==1.1.14
 termcolor==1.1.0


### PR DESCRIPTION
For some reason when I generated the requirements file it included a package that causes it to crash when running `pip install -r requirements.txt`.

This fixes that.